### PR TITLE
Compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ gstreamer).
 # Ubuntu
 
 ```bash
-apt-get install python3-scipy python3-pil
-apt-get install apt-get install gstreamer1.0-plugins-* gstreamer-tools
+sudo apt-get install python3-scipy python3-pil gstreamer1.0-plugins-*
 ```
+
+make_all.sh will install and run the statics, leave you with all the images.

--- a/make_all.sh
+++ b/make_all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+
+sudo apt-get install python3-scipy python3-pil gstreamer1.0-plugins-*
+
+cd static
+
+python3 circles.py
+python3 edges.py
+python3 lines.py
+python3 from-gstreamer.py
+
+python3 jpg.py

--- a/static/jpg.py
+++ b/static/jpg.py
@@ -33,7 +33,12 @@ convert \
         if not os.path.exists(cmp_dir):
             os.mkdir(cmp_dir)
 
-        subprocess.check_call("""
+# man compare ...  The compare program returns 2 on error,
+# 0 if the images are similar,
+# or a value between 0 and 1 if they are not similar.
+# so don't use check_call because that throws an exception
+
+        subprocess.call("""
 compare \
     -verbose -metric mae \
     input/{in_file}.png \


### PR DESCRIPTION
compare is special - expected operation returns error codes witch throws a python exception.  so drop the `.check_`

```
juser@cnt7:~/tv/test-patterns/static$ compare -verbose -metric mae input/lines-br-h-016px.png jpg-q050/lines-br-h-016px.jpg jpg-c050/lines-br-h-016px.png
input/lines-br-h-016px.png PNG 1280x720 1280x720+0+0 8-bit sRGB 4455B 0.020u 0:00.019
jpg-q050/lines-br-h-016px.jpg JPEG 1280x720 1280x720+0+0 8-bit sRGB 5809B 0.010u 0:00.009
Image: input/lines-br-h-016px.png
  Channel distortion: MAE
    red: 1733.32 (0.0264488)
    green: 188.467 (0.00287582)
    blue: 2838.42 (0.0433115)
    all: 1586.74 (0.0242121)
input/lines-br-h-016px.png=>jpg-c050/lines-br-h-016px.png PNG 1280x720 1280x720+0+0 8-bit sRGB 3c 1265B 0.100u 0:00.039
juser@cnt7:~/tv/test-patterns/static$ echo $?
1
```